### PR TITLE
Crates.io + Docs.rs Update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "suspend-time"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/Rippling/suspend-time"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 name = "suspend-time"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
+homepage = "https://github.com/Rippling/suspend-time"
+repository = "https://github.com/Rippling/suspend-time"
+readme = "README.md"
+description = "A cross-platform monotonic clock that is suspend-unaware, written in Rust!"
 
 [dependencies.windows-sys]
 version = "0.52"

--- a/README.md
+++ b/README.md
@@ -1,21 +1,44 @@
 # suspend-time
-A cross-platform monotonic clock that is suspend-unaware, written in Rust!
+Suspend-time is a cross-platform monotonic clock that is suspend-unaware, written in Rust!    
+It allows system suspension (e.g. when a user closes their laptop on windows) to not affect `Instant` durations and timeouts!
 
-**Documentation**: [to be hosted]
+**[API Documentation](https://docs.rs/suspend-time/latest/suspend_time/)**
 
 ## Example
+
+Example of using `SuspendUnawareInstant`:
 
 ```rust
 use std::{thread, time};
 use suspend_time::{SuspendUnawareInstant};
 
 fn main() {
+    // If you used std::time::Instant here and you suspend the system on windows,
+    // it will print that more than 3 seconds (circa July 2024).
+    // With SuspendUnawareInstant this has no effect.
     let instant = SuspendUnawareInstant::now();
     let three_secs = time::Duration::from_secs(3);
     thread::sleep(three_secs);
-    assert!(instant.elapsed() >= three_secs);
+    println!("{:#?}", instant.elapsed());
 }
 ```
+
+Example of using `suspend_time::timeout`:
+
+```rust
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() {
+    // If you suspend the system during main's execution, Tokio will time
+    // out even though it only slept for 1 second. suspend_time::timeout does not.
+    let _ = suspend_time::timeout(
+        Duration::from_secs(2),
+        suspend_time::sleep(Duration::from_secs(1)),
+    ).await;
+}
+```
+
 
 ## `Instant` vs `SuspendUnawareInstant`
 

--- a/examples/timeout.rs
+++ b/examples/timeout.rs
@@ -1,0 +1,12 @@
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() {
+    // If you suspend the system during main's execution, Tokio will time
+    // out even though it only slept for 1 second. `suspend_time::timeout` does not.
+    let _ = suspend_time::timeout(
+        Duration::from_secs(2),
+        suspend_time::sleep(Duration::from_secs(1)),
+    )
+    .await;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,39 @@
-//! A library to solve platform inconsistencies in the standard time library,
-//! specifically surrounding system suspension.  See [`SuspendUnawareInstant`]
-//! for more details
+//! Suspend-time is a cross-platform monotonic clock that is suspend-unaware, written in Rust!
+//! It allows system suspension (e.g. when a user closes their laptop on windows) to not affect
+//! `Instant` durations and timeouts!
+//!
+//! Example of using [`SuspendUnawareInstant`]:
+//! ```
+//! use std::{thread, time};
+//! use suspend_time::{SuspendUnawareInstant};
+//!
+//! fn main() {
+//!     // If you used std::time::Instant here and you suspend the system on windows,
+//!     // it will print that more than 3 seconds (circa July 2024).
+//!     // With SuspendUnawareInstant this has no effect.
+//!     let instant = SuspendUnawareInstant::now();
+//!     let three_secs = time::Duration::from_secs(3);
+//!     thread::sleep(three_secs);
+//!     println!("{:#?}", instant.elapsed());
+//! }
+//! ```
+//!
+//! Example of using `suspend_time::`[`timeout`]
+//!
+//! ```
+//! use std::time::Duration;
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     // If you suspend the system during main's execution, Tokio will time
+//!     // out even though it only slept for 1 second. suspend_time::timeout does not.
+//!     let _ = suspend_time::timeout(
+//!         Duration::from_secs(2),
+//!         suspend_time::sleep(Duration::from_secs(1)),
+//!     ).await;
+//! }
+//! ```
+//!
 use std::{
     error::Error,
     fmt,
@@ -197,6 +230,7 @@ impl fmt::Display for TimedOutError {
 
 impl Error for TimedOutError {}
 
+/// The same API as tokio::time::timeout, except it is dependant on SuspendUnawareInstant for measuring time.
 pub async fn timeout<'a, F>(duration: Duration, future: F) -> Result<F::Output, TimedOutError>
 where
     F: Future + 'a,
@@ -211,6 +245,7 @@ where
     }
 }
 
+/// The same API as tokio::time::sleep, except it is dependant on SuspendUnawareInstant for measuring time.
 pub async fn sleep(duration: Duration) {
     let deadline = SuspendUnawareInstant::now() + duration;
     let mut now = SuspendUnawareInstant::now();


### PR DESCRIPTION
Patches:
- Updated some of the public documentation
- Added required fields to `Cargo.toml` for crates.io
- Added a timeout example in `examples/timeout.rs`
- Version bumped to v0.1.1

@brhoades is now also an [owner of suspend-time on crates.io](https://crates.io/crates/suspend-time). I don't see this reflected on the public site yet, so Billy you might need to make an account on crates.io for it to be fully reflected.